### PR TITLE
Fixed broken example in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,8 +18,8 @@ var client = new modbus.Client();
 var server = new modbus.Server();
 
 // link client and server streams together
-client.pipe(server.pipe());
-server.pipe(client.pipe());
+client.writer().pipe(server.reader());
+server.writer().pipe(client.reader());
 
 server.on("read-coils", function (from, to, reply) {
     return reply(null, [ 1, 0, 1, 1 ]);
@@ -28,6 +28,7 @@ server.on("read-coils", function (from, to, reply) {
 // read coils from unit id = 0, from address 10 to 13
 client.readCoils(0, 10, 13, function (err, coils) {
     // coils = [ 1, 0, 1, 1 ]
+    console.log(coils);
 });
 ```
 


### PR DESCRIPTION
The example code in the readme didn't run:

	/Users/vicwid/code/swxl/node_modules/modbus-tcp/lib/Server/Server.js:40
			stream.pipe(reader);
			       ^
	TypeError: Cannot call method 'pipe' of undefined
	    at Server.pipe (/Users/vicwid/code/swxl/node_modules/modbus-tcp/lib/Server/Server.js:40:10)
	    at Object.<anonymous> (/Users/vicwid/code/swxl/modbustest.js:6:20)
	    at Module._compile (module.js:456:26)
	    at Object.Module._extensions..js (module.js:474:10)
	    at Module.load (module.js:356:32)
	    at Function.Module._load (module.js:312:12)
	    at Function.Module.runMain (module.js:497:10)
	    at startup (node.js:119:16)
	    at node.js:901:3

I fixed it by modifying the piping to match the code in the tests.

I also added a console.log() to the response callback, so the code outputs something.