### PR TITLE
Fix pending buffer length check

### DIFF
--- a/lib/Server/ReadStream.js
+++ b/lib/Server/ReadStream.js
@@ -29,10 +29,11 @@ ReadStream.prototype._transform = function (chunk, encoding, next) {
 		this.pending = Buffer.concat([ this.pending, chunk ]);
 	}
 
-	while (this.pending.length >= 6) {
+	while (this.pending.length >= 12) {
 		var pkg_len = this.pending.readUInt16BE(4) + 6;
 
 		if (this.pending.length < pkg_len) return next();
+		if (pkg_len < 12) return next(); // every function code needs at least 4 additional bytes for "from" and "to". TODO: for WRITE_MULTIPLE_*, we could even check in more detail
 
 		var data = this.pending.slice(8, pkg_len);
 		var pkg  = {


### PR DESCRIPTION
We need more than just 6 bytes for a packet to make sense. At the very least 8, since we unconditionally readUInt8 from position 6 and 7 (lines 42 & 43), but even then every possible valid Modbus TCP message has at least from (2 bytes) and to (2 bytes) fields, unless I am overlooking something.

Without this, it's trivial to DoS the modbus-tcp Server, e.g. by sending 6 0x00 bytes which will lead to an uncaught exception:

RangeError: Trying to access beyond buffer length

RangeError: Trying to access beyond buffer length
    at checkOffset (buffer.js:582:11)
    at Buffer.readUInt16BE (buffer.js:602:5)
    at ReadStream._transform ([...]/node_modules/modbus-tcp/lib/Server/ReadStream.js:66:24)
    at ReadStream._write ([...]/node_modules/modbus-tcp/lib/Server/ReadStream.js:105:18)
    at doWrite (_stream_writable.js:226:10)
    at writeOrBuffer (_stream_writable.js:216:5)
    at ReadStream.Writable.write (_stream_writable.js:183:11)
    at write (_stream_readable.js:602:24)
    at flow (_stream_readable.js:611:7)
    at Socket.pipeOnReadable (_stream_readable.js:643:5)
    at Socket.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:427:10)
