### PR TITLE
Checking incoming packet length on server side

### DIFF
--- a/lib/Server/ReadStream.js
+++ b/lib/Server/ReadStream.js
@@ -48,30 +48,37 @@ ReadStream.prototype._transform = function (chunk, encoding, next) {
 
 		switch (pkg.functionCode) {
 			case 'READ_COILS':
+				if (data.length < 4) continue;
 				pkg.from = data.readUInt16BE(0);
 				pkg.to = data.readUInt16BE(2) + pkg.from - 1;
 				break;
 			case 'READ_DISCRETE_INPUTS':
+				if (pkg.length < 4) continue;
 				pkg.from = data.readUInt16BE(0);
 				pkg.to = data.readUInt16BE(2) + pkg.from - 1;
 				break;
 			case 'READ_HOLDING_REGISTERS':
+				if (pkg.length < 4) continue;
 				pkg.from = data.readUInt16BE(0);
 				pkg.to = data.readUInt16BE(2) + pkg.from - 1;
 				break;
 			case 'READ_INPUT_REGISTERS':
+				if (pkg.length < 4) continue;
 				pkg.from = data.readUInt16BE(0);
 				pkg.to = data.readUInt16BE(2) + pkg.from - 1;
 				break;
 			case 'WRITE_SINGLE_COIL':
+				if (pkg.length < 4) continue;
 				pkg.address = data.readUInt16BE(0);
 				pkg.value   = new Buffer([ data[2], data[3] ]);
 				break;
 			case 'WRITE_SINGLE_REGISTER':
+				if (pkg.length < 4) continue;
 				pkg.address = data.readUInt16BE(0);
 				pkg.value   = new Buffer([ data[2], data[3] ]);
 				break;
 			case 'WRITE_MULTIPLE_COILS':
+				if (pkg.length < 5) continue;
 				pkg.from   = data.readUInt16BE(0);
 				pkg.to     = data.readUInt16BE(2) + pkg.from - 1;
 				pkg.items  = [];
@@ -86,6 +93,7 @@ ReadStream.prototype._transform = function (chunk, encoding, next) {
 				}
 				break;
 			case 'WRITE_MULTIPLE_REGISTERS':
+				if (data.length < 5) continue;
 				pkg.from   = data.readUInt16BE(0);
 				pkg.to     = data.readUInt16BE(2) + pkg.from - 1;
 				pkg.items  = [];


### PR DESCRIPTION
Incoming packets with short function header did cause out of buffer errors

Example invalid write multiple holding registers command:
16 01 00 00  00 04 01 10  00 00

This PR checks that the data is at least as long as the header should be for the given command.